### PR TITLE
Updates monitoring setup for host network and Tailscale metrics

### DIFF
--- a/ansible/services/nix-metrics/compose.yaml
+++ b/ansible/services/nix-metrics/compose.yaml
@@ -1,25 +1,26 @@
 services:
-  grafana-ts:
-    image: tailscale/tailscale:latest
-    container_name: grafana-ts
-    hostname: grafana
-    volumes:
-      - ${PWD}/grafana/tailscale/state:/var/lib/tailscale
-      - /dev/net/tun:/dev/net/tun
-    cap_add:
-      - NET_ADMIN
-      - NET_RAW
-    environment:
-      - "TS_AUTH_KEY=${TS_AUTH_KEY}"
-      - TS_STATE_DIR=/var/lib/tailscale
-      - TS_ENABLE_METRICS=${TS_ENABLE_METRICS}
-    restart: unless-stopped
+  # grafana-ts:
+  #   image: tailscale/tailscale:latest
+  #   container_name: grafana-ts
+  #   hostname: grafana
+  #   volumes:
+  #     - ${PWD}/grafana/tailscale/state:/var/lib/tailscale
+  #     - /dev/net/tun:/dev/net/tun
+  #   cap_add:
+  #     - NET_ADMIN
+  #     - NET_RAW
+  #   environment:
+  #     - "TS_AUTH_KEY=${TS_AUTH_KEY}"
+  #     - TS_STATE_DIR=/var/lib/tailscale
+  #     - TS_ENABLE_METRICS=${TS_ENABLE_METRICS}
+  #   restart: unless-stopped
 
   grafana:
     image: grafana/grafana:latest
     container_name: grafana
     restart: unless-stopped
-    network_mode: service:grafana-ts
+    ports:
+      - "3000:3000"
     user: "${GRAFANA_USER_ID:-1000}:${GRAFANA_GROUP_ID:-1000}"
     environment:
       - GF_SECURITY_ADMIN_USER=${GF_SECURITY_ADMIN_USER}
@@ -31,27 +32,28 @@ services:
       - ${PWD}/grafana/provisioning:/etc/grafana/provisioning
       - ${PWD}/grafana/dashboards:/var/lib/grafana/dashboards
 
-  prometheus-ts:
-    image: tailscale/tailscale:latest
-    container_name: prometheus-ts
-    hostname: prometheus
-    volumes:
-      - ${PWD}/prometheus/tailscale/state:/var/lib/tailscale
-      - /dev/net/tun:/dev/net/tun
-    cap_add:
-      - NET_ADMIN
-      - NET_RAW
-    environment:
-      - "TS_AUTH_KEY=${TS_AUTH_KEY}"
-      - TS_STATE_DIR=/var/lib/tailscale
-      - TS_ENABLE_METRICS=${TS_ENABLE_METRICS}
-    restart: unless-stopped
+  # prometheus-ts:
+  #   image: tailscale/tailscale:latest
+  #   container_name: prometheus-ts
+  #   hostname: prometheus
+  #   volumes:
+  #     - ${PWD}/prometheus/tailscale/state:/var/lib/tailscale
+  #     - /dev/net/tun:/dev/net/tun
+  #   cap_add:
+  #     - NET_ADMIN
+  #     - NET_RAW
+  #   environment:
+  #     - "TS_AUTH_KEY=${TS_AUTH_KEY}"
+  #     - TS_STATE_DIR=/var/lib/tailscale
+  #     - TS_ENABLE_METRICS=${TS_ENABLE_METRICS}
+  #   restart: unless-stopped
 
   prometheus:
     image: prom/prometheus:latest
     container_name: prometheus
-    network_mode: service:prometheus-ts
     restart: unless-stopped
+    ports:
+      - "9090:9090"
     user: "${PROMETHEUS_USER_ID:-65534}:${PROMETHEUS_GROUP_ID:-65534}"
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
@@ -78,7 +80,7 @@ services:
     ports:
       - "9100:9100"
     # Make node-exporter accessible to host network
-    network_mode: "host"
+    # network_mode: "host"
 
   cadvisor:
     image: gcr.io/cadvisor/cadvisor:latest
@@ -93,7 +95,7 @@ services:
     ports:
       - "8080:8080"
     # Make cadvisor accessible to host network
-    network_mode: "host"
+    # network_mode: "host"
 
   # loadgen:
   #   build:

--- a/ansible/services/nix-metrics/compose.yaml
+++ b/ansible/services/nix-metrics/compose.yaml
@@ -77,8 +77,8 @@ services:
       - "--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)"
     ports:
       - "9100:9100"
-    networks:
-      - monitoring
+    # Make node-exporter accessible to host network
+    network_mode: "host"
 
   cadvisor:
     image: gcr.io/cadvisor/cadvisor:latest
@@ -92,8 +92,8 @@ services:
       - /dev/disk/:/dev/disk:ro
     ports:
       - "8080:8080"
-    networks:
-      - monitoring
+    # Make cadvisor accessible to host network
+    network_mode: "host"
 
   # loadgen:
   #   build:

--- a/ansible/services/nix-metrics/grafana/dashboards/dashboard.json
+++ b/ansible/services/nix-metrics/grafana/dashboards/dashboard.json
@@ -178,7 +178,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(tailscaled_inbound_packets_total{path=~\"$path\"}[5m])",
+          "expr": "rate(tailscaled_inbound_packets_total[5m])",
           "legendFormat": "inbound - {{path}}",
           "range": true,
           "refId": "A"
@@ -189,7 +189,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(tailscaled_outbound_packets_total{path=~\"$path\"}[5m])",
+          "expr": "rate(tailscaled_outbound_packets_total[5m])",
           "hide": false,
           "legendFormat": "outbound - {{path}}",
           "range": true,
@@ -345,16 +345,7 @@
   "tags": ["tailscale", "networking"],
   "templating": {
     "list": [
-      {
-        "allowCustomValue": false,
-        "label": "Datasource",
-        "name": "DS",
-        "options": [],
-        "query": "prometheus",
-        "refresh": 1,
-        "regex": "",
-        "type": "datasource"
-      },
+
       {
         "allowCustomValue": false,
         "current": {

--- a/ansible/services/nix-metrics/grafana/dashboards/dashboard.json
+++ b/ansible/services/nix-metrics/grafana/dashboards/dashboard.json
@@ -73,7 +73,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(tailscaled_inbound_bytes_total[5m]))",
+          "expr": "sum(rate(tailscaled_inbound_bytes_total{instance=~\"$host:5252\"}[5m]))",
           "legendFormat": "Inbound Bytes",
           "range": true,
           "refId": "A"
@@ -84,7 +84,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(tailscaled_outbound_bytes_total[5m]))",
+          "expr": "sum(rate(tailscaled_outbound_bytes_total{instance=~\"$host:5252\"}[5m]))",
           "legendFormat": "Outbound Bytes",
           "range": true,
           "refId": "B"
@@ -178,7 +178,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(tailscaled_inbound_packets_total[5m])",
+          "expr": "rate(tailscaled_inbound_packets_total{instance=~\"$host:5252\"}[5m])",
           "legendFormat": "inbound - {{path}}",
           "range": true,
           "refId": "A"
@@ -189,7 +189,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(tailscaled_outbound_packets_total[5m])",
+          "expr": "rate(tailscaled_outbound_packets_total{instance=~\"$host:5252\"}[5m])",
           "hide": false,
           "legendFormat": "outbound - {{path}}",
           "range": true,
@@ -257,15 +257,60 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "tailscaled_health_messages{type=\"warning\"}",
+          "expr": "tailscaled_health_messages{type=\"warning\", instance=~\"$host:5252\"} or vector(0)",
           "range": true,
           "refId": "A"
         }
       ],
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "repeat": null,
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "tailscaled_health_messages{type=\"warning\", instance=~\"$host:5252\"} or vector(0)",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
       "title": "Health Warnings",
-      "type": "stat"
+      "type": "stat",
+      "valueFontSize": "80px",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
     },
     {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(50, 172, 45, 0.97)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(245, 54, 54, 0.9)"
+      ],
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -288,6 +333,14 @@
         },
         "overrides": []
       },
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
       "gridPos": {
         "h": 8,
         "w": 12,
@@ -295,22 +348,40 @@
         "y": 8
       },
       "id": 4,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": ["lastNotNull"],
-          "fields": "",
-          "values": false
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
         },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
       "pluginVersion": "11.5.1",
+      "prefix": "",
+      "prefixFontSize": "50px",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "repeat": null,
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
       "targets": [
         {
           "datasource": {
@@ -318,7 +389,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "tailscaled_advertised_routes",
+          "expr": "tailscaled_advertised_routes{instance=~\"$host:5252\"}",
           "legendFormat": "Advertised Routes",
           "range": true,
           "refId": "A"
@@ -329,7 +400,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "tailscaled_approved_routes",
+          "expr": "tailscaled_approved_routes{instance=~\"$host:5252\"}",
           "legendFormat": "Approved Routes",
           "range": true,
           "refId": "B"
@@ -345,7 +416,33 @@
   "tags": ["tailscale", "networking"],
   "templating": {
     "list": [
-
+      {
+        "current": {
+          "selected": false,
+          "text": "nix-metrics",
+          "value": "nix-metrics"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(instance)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Host",
+        "multi": false,
+        "name": "host",
+        "options": [],
+        "query": {
+          "query": "label_values(instance)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "(.*):5252",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
       {
         "allowCustomValue": false,
         "current": {

--- a/ansible/services/nix-metrics/grafana/provisioning/datasources/prometheus.yaml
+++ b/ansible/services/nix-metrics/grafana/provisioning/datasources/prometheus.yaml
@@ -16,7 +16,7 @@ datasources:
     # <string, required> access mode. proxy or direct (Server or Browser in the UI). Required
     access: proxy
     # <string> url
-    url: ${PROMETHEUS_URL:-http://prometheus:9090}
+    url: ${PROMETHEUS_URL}
     # <bool> mark as default datasource. Default: false
     isDefault: true
     # <bool> allow users to edit datasources from the UI. Default: false

--- a/ansible/services/nix-metrics/prometheus/prometheus.yml
+++ b/ansible/services/nix-metrics/prometheus/prometheus.yml
@@ -14,7 +14,7 @@ alerting:
 scrape_configs:
   - job_name: 'prometheus'
     static_configs:
-      - targets: ['localhost:9090']
+      - targets: ['nix-metrics:9090']
 
   - job_name: 'node'
     static_configs:
@@ -24,7 +24,12 @@ scrape_configs:
     static_configs:
       - targets: ['nix-metrics:8080']
 
-  - job_name: 'promcontainer'
-    metrics_path: '/metrics'
+  - job_name: 'tailscale'
+    # metrics_path: '/metrics'
     static_configs:
-      - targets: ['nix-metrics:5252'] # tailscale set --webclient and tailscale metrics
+      - targets:
+        - 'nix-metrics:5252' # tailscale set --webclient and tailscale metrics
+        - 'n8n:5252'
+        - 'oi:5252'
+        - 'mini:5252'
+        - 'mb0:5252'

--- a/ansible/services/nix-metrics/prometheus/prometheus.yml
+++ b/ansible/services/nix-metrics/prometheus/prometheus.yml
@@ -18,11 +18,11 @@ scrape_configs:
 
   - job_name: 'node'
     static_configs:
-      - targets: ['node-exporter:9100']
+      - targets: ['nix-metrics:9100']
 
   - job_name: 'cadvisor'
     static_configs:
-      - targets: ['cadvisor:8080']
+      - targets: ['nix-metrics:8080']
 
   - job_name: 'promcontainer'
     metrics_path: '/metrics'

--- a/docs/nixos-vm-storage-resize.md
+++ b/docs/nixos-vm-storage-resize.md
@@ -1,0 +1,63 @@
+# VM Storage Resize Procedure for Proxmox NixOS VMs
+
+## Pre-requisites
+1. Take a backup of the VM in Proxmox
+2. Download Nixos or suitable Linux live ISO
+3. Ensure you have SSH access to the VM
+
+## Proxmox Steps
+1. Shut down the VM in Proxmox
+2. In Proxmox web interface:
+   - Select the VM
+   - Go to Hardware
+   - Select the hard disk
+   - Click "Resize"
+   - Enter the new size (e.g., +10G)
+3. Mount the live ISO in Proxmox VM settings
+4. Start the VM with the live ISO
+
+## Live Environment Steps
+1. Boot into the live environment
+2. Verify current partition structure:
+   ```bash
+   sudo parted /dev/vda print
+   # or
+   lsblk /dev/vda
+   ```
+
+3. Extend the root partition to use all available space:
+   ```bash
+   sudo parted /dev/vda resizepart 2 100%
+   ```
+
+4. Resize the filesystem to use the new partition size:
+   ```bash
+   # For ext4 filesystem:
+   sudo resize2fs /dev/vda2
+   # For xfs filesystem:
+   sudo xfs_growfs /dev/vda2
+   ```
+
+5. Verify the new sizes:
+   ```bash
+   sudo parted /dev/vda print
+   lsblk /dev/vda
+   ```
+
+## Post-Resize Steps
+1. Shut down the live environment
+2. Remove the ISO from Proxmox VM settings
+3. Start the VM normally
+4. Verify disk space with 'df -h'
+
+Notes:
+- Always backup important data before resizing
+- Replace vda with your actual device name (check with 'lsblk')
+- If using LVM, additional steps may be needed
+- Consider rebooting after resize if system is heavily utilized
+- In case of boot issues, you can always return to the live environment
+
+Troubleshooting:
+- If partition table shows errors, you may need to use 'fdisk' to fix GPT issues
+- Always have a backup bootable ISO ready
+- Keep Proxmox backup available for recovery

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1745921652,
-        "narHash": "sha256-hEAvEN+y/OQ7wA7+u3bFJwXSe8yoSf2QaOMH3hyTJTQ=",
+        "lastModified": 1746557022,
+        "narHash": "sha256-QkNoyEf6TbaTW5UZYX0OkwIJ/ZMeKSSoOMnSDPQuol0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b000159bba69b0106a42f65e52dbf27f77aca9d3",
+        "rev": "1d3aeb5a193b9ff13f63f4d9cc169fb88129f860",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1745930157,
-        "narHash": "sha256-y3h3NLnzRSiUkYpnfvnS669zWZLoqqI6NprtLQ+5dck=",
+        "lastModified": 1746461020,
+        "narHash": "sha256-7+pG1I9jvxNlmln4YgnlW4o+w0TZX24k688mibiFDUE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "46e634be05ce9dc6d4db8e664515ba10b78151ae",
+        "rev": "3730d8a308f94996a9ba7c7138ede69c1b9ac4ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Disabled Tailscale sidecar services for Grafana and Prometheus, now exposing their ports directly for easier access.
	- Updated Grafana dashboard queries to filter metrics by selected host instances and improved visualisation of health and routes panels.
	- Modified Prometheus datasource configuration in Grafana to require an explicit URL, removing the default fallback.
	- Consolidated and expanded Prometheus scrape targets, including a new Tailscale job with multiple hosts.
- **Documentation**
	- Added a comprehensive guide for resizing storage on Proxmox NixOS virtual machines, covering preparation, resizing steps, and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->