### PR TITLE
Add Dockge container management with centralized directory

### DIFF
--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -1,18 +1,52 @@
 ---
+  - hosts: all # New play for Dockge, targets all hosts
+    vars:
+      docker_compose_output_path: "/opt/dockge"
+      docker_compose_generator_output_path: "/opt/dockge"
+      # This variable tells the docker-compose-generator role to look for
+      # YAML files specifically in the 'ansible/services/dockge/' directory.
+      docker_compose_hostname: "dockge"
+    tasks:
+      - name: Ensure /opt/dockge base directory exists
+        ansible.builtin.file:
+          path: "{{ docker_compose_output_path }}"
+          state: directory
+          mode: '0755'
+        tags: [config_files, dockge_config] # ADDED dockge_config
+
+      - name: Ensure /opt/dockge/data directory exists for Dockge persistent data
+        ansible.builtin.file:
+          path: "{{ docker_compose_output_path }}/data" # Corresponds to ./data in dockge's compose.yaml
+          state: directory
+          mode: '0755' # Adjust owner/group if needed by dockge image
+        tags: [config_files, dockge_config] # ADDED dockge_config
+
+      - name: Ensure /opt/stacks directory exists for Dockge managed stacks
+        ansible.builtin.file:
+          path: /opt/stacks # This is the directory Dockge will manage
+          state: directory
+          mode: '0755'
+        tags: [config_files, dockge_config] # ADDED dockge_config
+    roles:
+      - role: ironicbadger.docker-compose-generator
+        tags: [compose, dockge_compose] # CHANGED to list and added dockge_compose
+
   - hosts: nix-llm
     vars:
-      docker_compose_output_path: "/opt/llm"
-      docker_compose_generator_output_path: "/opt/llm"
+      docker_compose_output_path: "/opt/stacks/llm"
+      docker_compose_generator_output_path: "/opt/stacks/llm"
+      # docker_compose_hostname is not set here, so it defaults to inventory_hostname 'nix-llm'
+      # The generator will look for services in 'ansible/services/nix-llm/'
     tasks:
-      - name: Ensure /opt/llm directory exists
-        file:
+      - name: Ensure /opt/stacks/llm directory exists
+        ansible.builtin.file:
           path: "{{ docker_compose_output_path }}"
           state: directory
           mode: '0755'
         tags: [compose, config_files, llm_config]
 
       - name: Copy openwebui.json file
-        copy:
+        ansible.builtin.copy:
           src: "{{ playbook_dir }}/services/nix-llm/openwebui.json"
           dest: "{{ docker_compose_output_path }}/openwebui.json"
         tags: [compose, config_files, llm_config]
@@ -22,45 +56,47 @@
 
   - hosts: nix-metrics
     vars:
-      docker_compose_output_path: "/opt/metrics"
-      docker_compose_generator_output_path: "/opt/metrics"
+      docker_compose_output_path: "/opt/stacks/metrics"
+      docker_compose_generator_output_path: "/opt/stacks/metrics"
+      # docker_compose_hostname is not set, defaults to inventory_hostname 'nix-metrics'
+      # The generator will look for services in 'ansible/services/nix-metrics/'
       prometheus_user_id: "65534"
       prometheus_group_id: "65534"
       grafana_user_id: "1000"
       grafana_group_id: "1000"
     tasks:
-      - name: Ensure /opt/metrics directory exists
-        file:
+      - name: Ensure /opt/stacks/metrics directory exists
+        ansible.builtin.file:
           path: "{{ docker_compose_output_path }}"
           state: directory
           mode: '0755'
         tags: [compose, config_files, metrics_config]
 
       - name: Copy all files and directories from nix-metrics
-        copy:
+        ansible.builtin.copy:
           src: "{{ playbook_dir }}/services/nix-metrics/"
           dest: "{{ docker_compose_output_path }}/"
           directory_mode: '0755'
         tags: [compose, config_files, metrics_config]
-        
+
       - name: Copy .env.example to .env if .env doesn't exist
-        copy:
+        ansible.builtin.copy:
           src: "{{ playbook_dir }}/services/nix-metrics/.env.example"
           dest: "{{ docker_compose_output_path }}/.env"
           force: no
         tags: [compose, config_files, metrics_config]
-        
+
       - name: Ensure Prometheus data directory exists
-        file:
+        ansible.builtin.file:
           path: "{{ docker_compose_output_path }}/prometheus/data"
           state: directory
           mode: '0755'
           owner: "{{ prometheus_user_id }}"
           group: "{{ prometheus_group_id }}"
         tags: [compose, config_files, metrics_config]
-        
+
       - name: Ensure Grafana directories exist with correct permissions
-        file:
+        ansible.builtin.file:
           path: "{{ docker_compose_output_path }}/{{ item }}"
           state: directory
           mode: '0755'
@@ -79,19 +115,20 @@
 
   - hosts: nix-komodo
     vars:
+      # This ensures the generator role looks for YAMLs in 'ansible/services/nix-komodo/'
       docker_compose_hostname: "nix-komodo"
-      docker_compose_output_path: "/opt/komodo"
-      docker_compose_generator_output_path: "/opt/komodo"
+      docker_compose_output_path: "/opt/stacks/komodo"
+      docker_compose_generator_output_path: "/opt/stacks/komodo"
     tasks:
-      - name: Ensure /opt/komodo directory exists
-        file:
+      - name: Ensure /opt/stacks/komodo directory exists
+        ansible.builtin.file:
           path: "{{ docker_compose_output_path }}"
           state: directory
           mode: '0755'
         tags: [compose, config_files, komodo_config]
 
       - name: Copy .env file
-        copy:
+        ansible.builtin.copy:
           src: "{{ playbook_dir }}/services/nix-komodo/.env"
           dest: "{{ docker_compose_output_path }}/.env"
         tags: [compose, config_files, komodo_config]

--- a/ansible/services/dockge/.env.example
+++ b/ansible/services/dockge/.env.example
@@ -1,0 +1,2 @@
+# Dockge
+DOCKGE_ENABLE_CONSOLE=true

--- a/ansible/services/dockge/compose.yaml
+++ b/ansible/services/dockge/compose.yaml
@@ -1,5 +1,3 @@
-# ansible/services/dockge/compose.yaml
-version: "3.8"
 services:
   dockge:
     image: louislam/dockge:1

--- a/ansible/services/dockge/compose.yaml
+++ b/ansible/services/dockge/compose.yaml
@@ -1,6 +1,6 @@
 services:
   dockge:
-    image: louislam/dockge:1
+    image: louislam/dockge:1.5.0
     restart: unless-stopped
     ports:
       - "5001:5001" # Or your preferred host port
@@ -13,3 +13,5 @@ services:
     environment:
       # Tells dockge where to find/create its managed stacks
       - DOCKGE_STACKS_DIR=/opt/stacks
+      # Docker image v1.5.0 disables the console by default for security.
+      - DOCKGE_ENABLE_CONSOLE=${DOCKGE_ENABLE_CONSOLE:-false}

--- a/ansible/services/dockge/compose.yaml
+++ b/ansible/services/dockge/compose.yaml
@@ -1,0 +1,17 @@
+# ansible/services/dockge/compose.yaml
+version: "3.8"
+services:
+  dockge:
+    image: louislam/dockge:1
+    restart: unless-stopped
+    ports:
+      - "5001:5001" # Or your preferred host port
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      # This will map to /opt/dockge/data on the host (see playbook changes)
+      - ./data:/app/data
+      # This allows dockge to see and manage stacks in /opt/stacks
+      - /opt/stacks:/opt/stacks
+    environment:
+      # Tells dockge where to find/create its managed stacks
+      - DOCKGE_STACKS_DIR=/opt/stacks

--- a/ansible/services/dockge/compose.yaml
+++ b/ansible/services/dockge/compose.yaml
@@ -7,7 +7,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       # This will map to /opt/dockge/data on the host (see playbook changes)
-      - ./data:/app/data
+      - /opt/dockge/data:/app/data
       # This allows dockge to see and manage stacks in /opt/stacks
       - /opt/stacks:/opt/stacks
     environment:

--- a/justfile
+++ b/justfile
@@ -111,3 +111,7 @@ metrics-config HOST *V:
 # Copy Komodo configuration files to remote hosts
 komodo-config HOST *V:
   cd ansible && ansible-playbook playbook.yaml --limit {{HOST}} --tags komodo_config {{V}}
+
+# Deploy Dockge configuration and compose files to remote host(s)
+dockge-deploy HOST *V:
+  cd ansible && ansible-playbook playbook.yaml --limit {{HOST}} --tags dockge_config,dockge_compose {{V}}


### PR DESCRIPTION
This update integrates Dockge for container management by introducing a new play targeting all hosts with a centralized directory structure at /opt/stacks. 

### Key Changes:
- **New Play for Dockge**: Configures a new play in the Ansible playbook to manage Dockge containers, including setting up necessary directories and roles.
- **Centralized Directory Structure**: Transitions existing configurations for LLM, metrics, and komodo hosts to utilize a unified /opt/stacks directory, simplifying management and organization.
- **New Dockge Service**: Adds a Docker Compose configuration for Dockge, mapping volumes for persistent data and stack management.
- **Command Additions**: Updates the justfile with a new command to deploy Dockge configurations.

### Benefits:
- Simplifies management with a centralized directory for all managed stacks, enhancing maintainability and scalability.
- Provides a streamlined setup process for Dockge, reducing manual configuration steps.
- Improves consistency across different host setups, promoting a standardized deployment approach.

This enhancement addresses the need for more efficient container management and aligns with ongoing infrastructure optimization efforts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced deployment and configuration support for the Dockge service, including a new Docker Compose setup and Ansible play.
	- Added a justfile command for streamlined Dockge deployment.
	- Provided an example environment file for Dockge configuration.
- **Improvements**
	- Updated service deployment directories for existing services to use subdirectories under /opt/stacks.
	- Enhanced Ansible playbook consistency by using fully qualified module names and list-based tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->