### PR TITLE
Add nix-claw-black: Sherif's personal AI bot (OpenClaw)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,11 @@
           hostname = "nix-komodo-02";
           username = "zerodeth";
         };
+        nix-claw-black = libx.mkNixos {
+          system = "x86_64-linux";
+          hostname = "black";
+          username = "zerodeth";
+        };
       };
     };
 }

--- a/hosts/nixos/nix-claw-black/default.nix
+++ b/hosts/nixos/nix-claw-black/default.nix
@@ -1,0 +1,92 @@
+# nix-claw-black: Sherif's personal AI bot (OpenClaw)
+# Integrates OpenClaw + Tailscale + Doppler + Docker
+{ pkgs, unstablePkgs, ... }:
+
+{
+  imports = [
+    ./../common/nixos.nix
+    ./../common/packages.nix
+  ];
+
+  # Boot configuration
+  boot.loader = {
+    systemd-boot.enable = true;
+    efi.canTouchEfiVariables = true;
+  };
+
+  # Network configuration
+  networking = {
+    firewall.enable = false;
+    hostName = "black";
+    # Tailscale will handle networking
+  };
+
+  # Timezone
+  i18n.defaultLocale = "en_GB.UTF-8";
+
+  # Disable X server
+  services.xserver.enable = false;
+
+  # SSH (via Tailscale)
+  services.openssh = {
+    enable = true;
+    settings.PasswordAuthentication = false;
+    settings.PermitRootLogin = "yes";
+  };
+
+  # Tailscale mesh networking
+  services.tailscale = {
+    enable = true;
+    usePredictableInterfaceNames = true;
+  };
+
+  # Docker for OpenClaw
+  virtualisation.docker = {
+    enable = true;
+    autoPrune = {
+      enable = true;
+      dates = "weekly";
+      flags = [ "--all" ];
+    };
+  };
+
+  # OpenClaw bot service
+  # Runs as Docker container via docker-compose
+  systemd.services.openclaw-black = {
+    description = "OpenClaw Black - Sherif's personal AI";
+    after = [ "network.target" "docker.service" ];
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      ExecStart = "${pkgs.docker-compose}/bin/docker-compose up -d";
+      ExecStop = "${pkgs.docker-compose}/bin/docker-compose down";
+      WorkingDirectory = "/opt/openclaw-black";
+    };
+  };
+
+  # Ensure /opt/openclaw-black exists
+  systemd.tmpfiles.rules = [
+    "d /opt/openclaw-black 0755 root root -"
+  ];
+
+  # User configuration
+  users.users.zerodeth = {
+    isNormalUser = true;
+    description = "zerodeth";
+    extraGroups = [ "networkmanager" "wheel" "docker" ];
+  };
+
+  # Environment variables for Doppler
+  environment.sessionVariables = {
+    DOPPLER_ENVIRONMENT = "dev";
+    DOPPLER_PROJECT = "black";
+  };
+
+  # Packages
+  environment.systemPackages = with pkgs; [
+    docker-compose
+    tailscale
+    git
+  ];
+}

--- a/hosts/nixos/nix-claw-black/install-nix.sh
+++ b/hosts/nixos/nix-claw-black/install-nix.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Install NixOS for nix-claw-black
+# Usage: sh install-nix.sh nix-claw-black
+
+# Check if the script is running as root
+if [ "$EUID" -ne 0 ]; then
+  echo "This script must be run as root"
+  exit 1
+fi
+
+# Clone kosnip if not already present
+if [ ! -d "/root/kosnip" ]; then
+  git clone https://github.com/ZeroDeth/kosnip.git /root/kosnip
+fi
+
+cd /root/kosnip/hosts/nixos/nix-claw-black
+
+# Run disko to partition and format disk
+nix --experimental-features "nix-command flakes" run github:nix-community/disko -- --mode disko ./disko.nix
+
+# Generate nixos configuration
+nixos-generate-config --no-filesystems --root /mnt
+
+# Copy hardware configuration
+cp ./hardware-configuration.nix /mnt/etc/nixos/
+
+# Install NixOS
+export NIXPKGS_ALLOW_UNFREE=1
+nixos-install --root /mnt --flake .#nix-claw-black --impure
+
+echo "Installation complete! Don't forget to set root password before rebooting."


### PR DESCRIPTION
Add nix-claw-black machine with OpenClaw bot integration.

- Machine name: nix-claw-black
- Hostname: black (for Tailscale)
- OpenClaw + Tailscale + Docker + Doppler integration
- Follows existing kosnip patterns

Review: https://github.com/ZeroDeth/kosnip/pull/new/pr/nix-claw-black