### PR TITLE
Add nix-claw-black: Sherif's personal AI bot

### DIFF
--- a/PREREQUISITES.md
+++ b/PREREQUISITES.md
@@ -23,17 +23,16 @@
 | Item | Required | Value |
 |------|----------|-------|
 | GitHub user | Yes | `clawzero` |
-| SSH keys | Yes | `id_ed25519-{name}-claw` in dotfiles repo |
-| GPG keys | Yes | `{name}-claw.asc` in dotfiles repo |
-| Repository | Yes | `clawzero/kosnip` |
+| SSH public keys | Yes | `id_ed25519-{name}-claw.pub` in claw-dot repo |
+| SSH private keys | Yes | In Doppler (secret storage) |
+| GPG public keys | Yes | `{name}-claw.asc` in claw-dot repo |
+| GPG private keys | Yes | In Doppler (secret storage) |
+| Repository | Yes | `clawzero/claw-nix` |
 
-**Keys location:**
+**Keys storage:**
 ```
-https://github.com/clawzero/dotfiles/raw/main/keys/{name}-claw/
-├── id_ed25519.pub      # SSH public key
-├── id_ed25519          # SSH private key
-├── {name}-claw.asc     # GPG public key
-└── {name}-claw.secret  # GPG private key
+Public keys  ──► claw-dot repo (anyone can read)
+Private keys ──► Doppler (secret storage)
 ```
 
 ---
@@ -113,7 +112,7 @@ doppler secrets set ANTHROPIC_API_KEY="..." --project pink-claw --config dev_pin
 ## Repository Structure
 
 ```
-kosnip/
+claw-nix/
 ├── PREREQUISITES.md          # This file
 ├── hosts/
 │   ├── common/

--- a/PREREQUISITES.md
+++ b/PREREQUISITES.md
@@ -4,67 +4,73 @@
 
 ---
 
-## Doppler
+## Naming Convention
 
-| Secret | Required | Example |
-|--------|----------|---------|
-| `DOPPLER_TOKEN` | Yes | Service token for Doppler CLI |
-| `TELEGRAM_BOT_TOKEN` | Yes (if Telegram channel) | Telegram bot token |
-| `ANTHROPIC_API_KEY` | Yes | Claude API key |
-| `OPENAI_API_KEY` | Optional | GPT-4 API key |
-
-**Doppler project must exist:**
-- Named matching the bot (e.g., `black`, `green`, `pink`)
-- Environment: `dev` (default)
-- Service token with `secrets.read` scope
+| Component | Pattern | Example |
+|-----------|---------|---------|
+| Machine name | `{name}` | `black` |
+| Hostname | `{name}` | `black` |
+| User | `{name}` | `black` |
+| SSH/GPG keys | `{name}-claw` | `black-claw` |
+| Doppler workspace | `claw` | `claw` |
+| Doppler project | `{name}-claw` | `black-claw` |
+| Doppler env | `dev_{name}` | `dev_black` |
 
 ---
 
 ## GitHub
 
-| Item | Required | Notes |
+| Item | Required | Value |
 |------|----------|-------|
-| Repository | Yes | Where bot config lives |
-| Branch protection | No | Optional for production bots |
-| GitHub Actions secrets | Optional | For CI/CD deployment |
+| GitHub user | Yes | `clawzero` |
+| SSH keys | Yes | `id_ed25519-{name}-claw` in dotfiles repo |
+| GPG keys | Yes | `{name}-claw.asc` in dotfiles repo |
+| Repository | Yes | `clawzero/kosnip` |
+
+**Keys location:**
+```
+https://github.com/clawzero/dotfiles/raw/main/keys/{name}-claw/
+├── id_ed25519.pub      # SSH public key
+├── id_ed25519          # SSH private key
+├── {name}-claw.asc     # GPG public key
+└── {name}-claw.secret  # GPG private key
+```
+
+---
+
+## Doppler
+
+| Variable | Value | Example |
+|----------|-------|---------|
+| `DOPPLER_WORKSPACE` | `claw` | `claw` |
+| `DOPPLER_PROJECT` | `{name}-claw` | `black-claw` |
+| `DOPPLER_ENVIRONMENT` | `dev_{name}` | `dev_black` |
+| `DOPPLER_CONFIG` | `dev_{name}` | `dev_black` |
+
+**Required secrets in Doppler:**
+- `TELEGRAM_BOT_TOKEN` (if Telegram channel)
+- `ANTHROPIC_API_KEY`
+- `OPENAI_API_KEY` (optional)
+
+**Setup:**
+```bash
+# Create Doppler project
+doppler projects create "black-claw" --workspace claw
+
+# Set secrets
+doppler secrets set TELEGRAM_BOT_TOKEN="..." --project black-claw --config dev_black
+doppler secrets set ANTHROPIC_API_KEY="..." --project black-claw --config dev_black
+```
 
 ---
 
 ## Tailscale
 
-| Item | Required | Notes |
+| Item | Required | Value |
 |------|----------|-------|
-| Tailscale account | Yes | Access to tailnet |
-| Auth key or OAuth | Yes | For auto-joining machines |
-| Machine hostname | Yes | e.g., `black.ts.net` |
-
----
-
-## Repository Structure
-
-```
-bots/
-├── hosts/
-│   └── nix-{bot-name}/
-│       ├── default.nix    # Bot configuration
-│       ├── install-nix.sh # Installation script
-│       └── README.md      # Bot documentation
-└── common/
-    └── bot/
-        ├── bot-preset.nix # Standardized configuration
-        └── README.md      # Preset documentation
-```
-
----
-
-## Naming Convention
-
-| Pattern | Example |
-|---------|---------|
-| Bot name | `black`, `green`, `pink` |
-| NixOS hostname | `black`, `green`, `pink` |
-| Doppler project | `black`, `green`, `pink` |
-| Tailscale hostname | `black.ts.net` |
+| Auth key | Yes | From Tailscale admin console |
+| Hostname | Yes | `{name}` | `black` |
+| Tailnet | Yes | Your tailnet |
 
 ---
 
@@ -72,31 +78,51 @@ bots/
 
 Before creating a new bot, verify:
 
-- [ ] Doppler project exists
-- [ ] Doppler service token created
+- [ ] GitHub user: `clawzero`
+- [ ] SSH key: `id_ed25519-{name}-claw` in dotfiles repo
+- [ ] GPG key: `{name}-claw.asc` in dotfiles repo
+- [ ] Doppler project: `{name}-cl claw`
+- [ ] Doppler environment: `dev_{name}`
+- [ ] Doppler secrets set
 - [ ] Tailscale auth key ready
-- [ ] Telegram bot token in Doppler (if needed)
-- [ ] API keys in Doppler (Claude, OpenAI, etc.)
-- [ ] Repository branch exists
-- [ ] Unique bot name (not used before)
+- [ ] Hostname: `{name}`
 
 ---
 
-## Example: Adding a New Bot
+## Example: Adding Pink Bot
 
 ```bash
-# 1. Verify prerequisites
-cat PREREQUISITES.md
+# 1. Add keys to dotfiles repo
+#    https://github.com/clawzero/dotfiles/tree/main/keys/pink-claw/
 
 # 2. Create Doppler project
-doppler projects create "pink" --config dev
+doppler projects create "pink-claw" --workspace claw
 
 # 3. Add secrets
-doppler secrets set TELEGRAM_BOT_TOKEN="..." --project pink --config dev
+doppler secrets set TELEGRAM_BOT_TOKEN="..." --project pink-claw --config dev_pink
+doppler secrets set ANTHROPIC_API_KEY="..." --project pink-claw --config dev_pink
 
-# 4. Create Tailscale auth key
-#    (via Tailscale admin console)
+# 4. Create Tailscale auth key for "pink"
 
-# 5. Create bot config using bot-preset.nix
-#    (see hosts/common/bot/bot-preset.nix)
+# 5. Create bot config:
+#    hosts/nixos/nix-pink/default.nix
+```
+
+---
+
+## Repository Structure
+
+```
+kosnip/
+├── PREREQUISITES.md          # This file
+├── hosts/
+│   ├── common/
+│   │   └── bot/
+│   │       ├── bot-preset.nix    # Standardized config
+│   │       └── README.md         # Preset docs
+│   └── nixos/
+│       └── nix-{name}/
+│           ├── default.nix       # Bot config (uses preset)
+│           ├── install-nix.sh    # Installation script
+│           └── README.md         # Bot docs
 ```

--- a/PREREQUISITES.md
+++ b/PREREQUISITES.md
@@ -1,0 +1,102 @@
+# Bot Prerequisites
+
+**Must be completed BEFORE creating a new bot.** No exceptions.
+
+---
+
+## Doppler
+
+| Secret | Required | Example |
+|--------|----------|---------|
+| `DOPPLER_TOKEN` | Yes | Service token for Doppler CLI |
+| `TELEGRAM_BOT_TOKEN` | Yes (if Telegram channel) | Telegram bot token |
+| `ANTHROPIC_API_KEY` | Yes | Claude API key |
+| `OPENAI_API_KEY` | Optional | GPT-4 API key |
+
+**Doppler project must exist:**
+- Named matching the bot (e.g., `black`, `green`, `pink`)
+- Environment: `dev` (default)
+- Service token with `secrets.read` scope
+
+---
+
+## GitHub
+
+| Item | Required | Notes |
+|------|----------|-------|
+| Repository | Yes | Where bot config lives |
+| Branch protection | No | Optional for production bots |
+| GitHub Actions secrets | Optional | For CI/CD deployment |
+
+---
+
+## Tailscale
+
+| Item | Required | Notes |
+|------|----------|-------|
+| Tailscale account | Yes | Access to tailnet |
+| Auth key or OAuth | Yes | For auto-joining machines |
+| Machine hostname | Yes | e.g., `black.ts.net` |
+
+---
+
+## Repository Structure
+
+```
+bots/
+├── hosts/
+│   └── nix-{bot-name}/
+│       ├── default.nix    # Bot configuration
+│       ├── install-nix.sh # Installation script
+│       └── README.md      # Bot documentation
+└── common/
+    └── bot/
+        ├── bot-preset.nix # Standardized configuration
+        └── README.md      # Preset documentation
+```
+
+---
+
+## Naming Convention
+
+| Pattern | Example |
+|---------|---------|
+| Bot name | `black`, `green`, `pink` |
+| NixOS hostname | `black`, `green`, `pink` |
+| Doppler project | `black`, `green`, `pink` |
+| Tailscale hostname | `black.ts.net` |
+
+---
+
+## Quick Checklist
+
+Before creating a new bot, verify:
+
+- [ ] Doppler project exists
+- [ ] Doppler service token created
+- [ ] Tailscale auth key ready
+- [ ] Telegram bot token in Doppler (if needed)
+- [ ] API keys in Doppler (Claude, OpenAI, etc.)
+- [ ] Repository branch exists
+- [ ] Unique bot name (not used before)
+
+---
+
+## Example: Adding a New Bot
+
+```bash
+# 1. Verify prerequisites
+cat PREREQUISITES.md
+
+# 2. Create Doppler project
+doppler projects create "pink" --config dev
+
+# 3. Add secrets
+doppler secrets set TELEGRAM_BOT_TOKEN="..." --project pink --config dev
+
+# 4. Create Tailscale auth key
+#    (via Tailscale admin console)
+
+# 5. Create bot config using bot-preset.nix
+#    (see hosts/common/bot/bot-preset.nix)
+```

--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,11 @@
           hostname = "nix-komodo-02";
           username = "zerodeth";
         };
+        nix-claw-black = libx.mkNixos {
+          system = "x86_64-linux";
+          hostname = "black";
+          username = "zerodeth";
+        };
       };
     };
 }

--- a/hosts/common/bot/README.md
+++ b/hosts/common/bot/README.md
@@ -90,7 +90,8 @@ Set via `bot.imageBackend`.
 ### Email Guardrails
 
 **Restricted recipients:**
-- Only `sherif@abdalla.co.uk` (and variants)
+- `sherif@abdalla.co.uk` (Sherif)
+- `pink@abdalla.co.uk` (Yesim)
 - No emails to unknown recipients
 
 **Consent required:**
@@ -106,7 +107,10 @@ programs.openclaw.config = {
     smtp.password = "$GMAIL_APP_PASSWORD";
     
     # Guardrails
-    allowedRecipients = [ "sherif@abdalla.co.uk" ];
+    allowedRecipients = [
+      "sherif@abdalla.co.uk"
+      "pink@abdalla.co.uk"
+    ];
     requireConsent = true;
     logAll = true;
   };

--- a/hosts/common/bot/README.md
+++ b/hosts/common/bot/README.md
@@ -15,13 +15,25 @@ Standardized configuration for all bots. **No exceptions.**
   bot = {
     enable = true;
     name = "black";
-    owner = "zerodeth";
-    project = "black";
-    environment = "dev";
+    owner = "clawzero";
+    project = "black-claw";
+    environment = "dev_black";
     enablePlugins = [ "sag" ];
   };
 }
 ```
+
+## Naming Convention
+
+| Component | Pattern | Example |
+|-----------|---------|---------|
+| Machine name | `{name}` | `black` |
+| Hostname | `{name}` | `black` |
+| User | `{name}` | `black` |
+| SSH/GPG keys | `{name}-claw` | `black-claw` |
+| Doppler workspace | `claw` | `claw` |
+| Doppler project | `{name}-claw` | `black-claw` |
+| Doppler env | `dev_{name}` | `dev_black` |
 
 ## Standard Paths (all bots)
 
@@ -35,11 +47,12 @@ Standardized configuration for all bots. **No exceptions.**
 
 ## Doppler (all bots)
 
-| Variable | Source |
-|----------|--------|
-| `DOPPLER_ENVIRONMENT` | bot.environment |
-| `DOPPLER_PROJECT` | bot.project |
-| `DOPPLER_CONFIG` | bot.environment |
+| Variable | Value | Example |
+|----------|-------|---------|
+| `DOPPLER_WORKSPACE` | `claw` | `claw` |
+| `DOPPLER_PROJECT` | `{name}-claw` | `black-claw` |
+| `DOPPLER_ENVIRONMENT` | `dev_{name}` | `dev_black` |
+| `DOPPLER_CONFIG` | `dev_{name}` | `dev_black` |
 
 ## First-Party Plugins
 
@@ -47,11 +60,23 @@ Standardized configuration for all bots. **No exceptions.**
 |--------|---------|
 | `sag` (TTS) | Enabled |
 
+## SSH & GPG Keys
+
+Keys stored in GitHub, pulled during initial setup:
+- SSH key: `id_ed25519-{name}-claw`
+- GPG key: `{name}-claw.asc`
+
+Setup script pulls keys from:
+```
+https://github.com/clawzero/dotfiles/raw/main/keys/{name}-claw/*
+```
+
 ## Included by Preset
 
 - Tailscale mesh networking
 - OpenClaw via nix-openclaw
 - Systemd service
-- User configuration
+- Doppler integration
+- User `{name}` (not zerodeth)
 - Standard directories
 - Base packages (tailscale, git, doppler)

--- a/hosts/common/bot/README.md
+++ b/hosts/common/bot/README.md
@@ -19,6 +19,7 @@ Standardized configuration for all bots. **No exceptions.**
     project = "black-claw";
     environment = "dev_black";
     enablePlugins = [ "sag" ];
+    imageBackend = "openai";  # openai, gemini, or brave
   };
 }
 ```
@@ -53,6 +54,29 @@ Standardized configuration for all bots. **No exceptions.**
 | `DOPPLER_PROJECT` | `{name}-claw` | `black-claw` |
 | `DOPPLER_ENVIRONMENT` | `dev_{name}` | `dev_black` |
 | `DOPPLER_CONFIG` | `dev_{name}` | `dev_black` |
+
+## AI Providers (standardized)
+
+| Role | Provider | Model |
+|------|----------|-------|
+| **Default** | MiniMax | `MiniMax-M2.1` |
+| **Failback** | Anthropic | `claude-opus-4-5` |
+
+## Image Analysis (configurable)
+
+| Option | Provider | Model |
+|--------|----------|-------|
+| `openai` | OpenAI | `gpt-4o` |
+| `gemini` | Google | `gemini-1.5-pro` |
+| `brave` | Brave | `brave-search` |
+
+Set via `bot.imageBackend`.
+
+## Web Search
+
+| Provider | API Key |
+|----------|---------|
+| Brave | `$BRAVE_API_KEY` |
 
 ## First-Party Plugins
 

--- a/hosts/common/bot/README.md
+++ b/hosts/common/bot/README.md
@@ -78,6 +78,41 @@ Set via `bot.imageBackend`.
 |----------|---------|
 | Brave | `$BRAVE_API_KEY` |
 
+## Email (Gmail with aliases)
+
+| Setting | Value |
+|---------|-------|
+| Main | clawzero.agent@gmail.com |
+| Alias format | clawzero.agent+{name}@gmail.com |
+| SMTP | smtp.gmail.com:587 |
+| App Password | `$GMAIL_APP_PASSWORD` (Doppler) |
+
+### Email Guardrails
+
+**Restricted recipients:**
+- Only `sherif@abdalla.co.uk` (and variants)
+- No emails to unknown recipients
+
+**Consent required:**
+- New recipients require explicit consent from Sherif
+- All emails logged
+
+```nix
+programs.openclaw.config = {
+  email = {
+    address = "clawzero.agent+${botCfg.name}@gmail.com";
+    smtp.host = "smtp.gmail.com";
+    smtp.user = "clawzero.agent@gmail.com";
+    smtp.password = "$GMAIL_APP_PASSWORD";
+    
+    # Guardrails
+    allowedRecipients = [ "sherif@abdalla.co.uk" ];
+    requireConsent = true;
+    logAll = true;
+  };
+};
+```
+
 ## First-Party Plugins
 
 | Plugin | Default |

--- a/hosts/common/bot/README.md
+++ b/hosts/common/bot/README.md
@@ -161,7 +161,7 @@ https://github.com/clawzero/dotfiles/raw/main/keys/{name}-claw/*
 ## Included by Preset
 
 - Tailscale mesh networking
-- OpenClaw via nix-openclaw
+- OpenClaw via nix-clawdbot (fork)
 - Systemd service
 - Doppler integration
 - User `{name}` (not zerodeth)

--- a/hosts/common/bot/README.md
+++ b/hosts/common/bot/README.md
@@ -78,16 +78,40 @@ Set via `bot.imageBackend`.
 |----------|---------|
 | Brave | `$BRAVE_API_KEY` |
 
-## Email (Gmail with aliases)
+## Email (configurable per bot)
 
-| Setting | Value |
-|---------|-------|
-| Main | clawzero.agent@gmail.com |
-| Alias format | clawzero.agent+{name}@gmail.com |
-| SMTP | smtp.gmail.com:587 |
-| App Password | `$GMAIL_APP_PASSWORD` (Doppler) |
+Each bot can have different email setup:
 
-### Email Guardrails
+| Bot | Email | SMTP |
+|-----|-------|------|
+| Yellow | `clawzero.agent+yellow@gmail.com` | smtp.gmail.com |
+| Pink | `yesim+pink@abdalla.co.uk` | Custom |
+
+### Configuration
+
+```nix
+bot = {
+  enable = true;
+  name = "yellow";
+  emailAddress = "clawzero.agent+yellow@gmail.com";
+  emailSmtpHost = "smtp.gmail.com";
+  emailSmtpUser = "clawzero.agent@gmail.com";
+  emailPasswordSecret = "GMAIL_APP_PASSWORD";
+};
+```
+
+```nix
+bot = {
+  enable = true;
+  name = "pink";
+  emailAddress = "yesim+pink@abdalla.co.uk";
+  emailSmtpHost = "smtp.custom.provider.com";
+  emailSmtpUser = "yesim+pink@abdalla.co.uk";
+  emailPasswordSecret = "PINK_EMAIL_PASSWORD";
+};
+```
+
+### Guardrails
 
 **Restricted recipients:**
 - `sherif@abdalla.co.uk` (Sherif)

--- a/hosts/common/bot/README.md
+++ b/hosts/common/bot/README.md
@@ -1,0 +1,57 @@
+# Bot Preset
+
+Standardized configuration for all bots. **No exceptions.**
+
+## Usage
+
+```nix
+{ pkgs, ... }:
+
+{
+  imports = [
+    ./../common/bot/bot-preset.nix
+  ];
+
+  bot = {
+    enable = true;
+    name = "black";
+    owner = "zerodeth";
+    project = "black";
+    environment = "dev";
+    enablePlugins = [ "sag" ];
+  };
+}
+```
+
+## Standard Paths (all bots)
+
+| Path | Purpose |
+|------|---------|
+| `/var/lib/openclaw` | State directory |
+| `/var/lib/openclaw/workspace` | Workspace |
+| `/var/lib/openclaw/openclaw.json` | Config |
+| `/tmp/openclaw/openclaw-gateway.log` | Logs |
+| `/run/secrets/openclaw-env` | Doppler secrets |
+
+## Doppler (all bots)
+
+| Variable | Source |
+|----------|--------|
+| `DOPPLER_ENVIRONMENT` | bot.environment |
+| `DOPPLER_PROJECT` | bot.project |
+| `DOPPLER_CONFIG` | bot.environment |
+
+## First-Party Plugins
+
+| Plugin | Default |
+|--------|---------|
+| `sag` (TTS) | Enabled |
+
+## Included by Preset
+
+- Tailscale mesh networking
+- OpenClaw via nix-openclaw
+- Systemd service
+- User configuration
+- Standard directories
+- Base packages (tailscale, git, doppler)

--- a/hosts/common/bot/bot-preset.nix
+++ b/hosts/common/bot/bot-preset.nix
@@ -180,6 +180,18 @@ in
             user = "clawzero.agent@gmail.com";
             password = "$GMAIL_APP_PASSWORD";
           };
+          
+          # Guardrails: Only send to authorized recipients
+          allowedRecipients = [
+            "sherif@abdalla.co.uk"  # Only Sherif can receive emails
+            "sherif+clawzero@abdalla.co.uk"
+          ];
+          
+          # Require consent for new recipients
+          requireConsent = true;
+          
+          # Log all emails
+          logAll = true;
         };
       };
     };

--- a/hosts/common/bot/bot-preset.nix
+++ b/hosts/common/bot/bot-preset.nix
@@ -23,6 +23,11 @@
 # FIRST-PARTY PLUGINS (enabled by default):
 #   - sag (TTS)
 #
+# AI PROVIDERS:
+#   - Default: minimax/MiniMax-M2.1
+#   - Failback: anthropic/claude-opus-4-5
+#   - Image: openai, gemini, or brave
+#
 # USAGE:
 #   { config, pkgs, ... }:
 #   {
@@ -73,6 +78,12 @@ in
       description = "First-party plugins to enable";
       default = [ "sag" ];
     };
+
+    imageBackend = lib.mkOption {
+      type = lib.types.enum [ "openai" "gemini" "brave" ];
+      description = "Image analysis backend";
+      default = "openai";
+    };
   };
 
   config = lib.mkIf botCfg.enable {
@@ -121,6 +132,38 @@ in
       
       firstParty = {
         sag.enable = lib.elem "sag" botCfg.enablePlugins;
+      };
+      
+      # AI Configuration (standardized)
+      config = {
+        # Default model: MiniMax
+        defaultModel = "minimax/MiniMax-M2.1";
+        
+        # Failback: Anthropic
+        providers = {
+          anthropic = {
+            apiKey = "$ANTHROPIC_API_KEY";
+            models = [ "claude-opus-4-5" ];
+          };
+          minimax = {
+            apiKey = "$MINIMAX_API_KEY";
+            models = [ "MiniMax-M2.1" ];
+          };
+        };
+        
+        # Image backend: openai, gemini, or brave
+        imageModel = {
+          provider = botCfg.imageBackend;
+          model = if botCfg.imageBackend == "openai" then "gpt-4o"
+            else if botCfg.imageBackend == "gemini" then "gemini-1.5-pro"
+            else "brave-search";
+        };
+        
+        # Search: Brave
+        webSearch = {
+          provider = "brave";
+          apiKey = "$BRAVE_API_KEY";
+        };
       };
     };
 

--- a/hosts/common/bot/bot-preset.nix
+++ b/hosts/common/bot/bot-preset.nix
@@ -84,6 +84,12 @@ in
       description = "Image analysis backend";
       default = "openai";
     };
+
+    emailAddress = lib.mkOption {
+      type = lib.types.str;
+      description = "Email address (Gmail with alias)";
+      default = "clawzero.agent+${botCfg.name}@gmail.com";
+    };
   };
 
   config = lib.mkIf botCfg.enable {
@@ -163,6 +169,17 @@ in
         webSearch = {
           provider = "brave";
           apiKey = "$BRAVE_API_KEY";
+        };
+        
+        # Email: Gmail with aliases
+        email = {
+          address = botCfg.emailAddress;
+          smtp = {
+            host = "smtp.gmail.com";
+            port = 587;
+            user = "clawzero.agent@gmail.com";
+            password = "$GMAIL_APP_PASSWORD";
+          };
         };
       };
     };

--- a/hosts/common/bot/bot-preset.nix
+++ b/hosts/common/bot/bot-preset.nix
@@ -87,8 +87,26 @@ in
 
     emailAddress = lib.mkOption {
       type = lib.types.str;
-      description = "Email address (Gmail with alias)";
+      description = "Email address (e.g., clawzero.agent+yellow@gmail.com or yesim+pink@abdalla.co.uk)";
       default = "clawzero.agent+${botCfg.name}@gmail.com";
+    };
+
+    emailSmtpHost = lib.mkOption {
+      type = lib.types.str;
+      description = "SMTP host (e.g., smtp.gmail.com or custom)";
+      default = "smtp.gmail.com";
+    };
+
+    emailSmtpUser = lib.mkOption {
+      type = lib.types.str;
+      description = "SMTP username";
+      default = "clawzero.agent@gmail.com";
+    };
+
+    emailPasswordSecret = lib.mkOption {
+      type = lib.types.str;
+      description = "Doppler secret name for email password";
+      default = "GMAIL_APP_PASSWORD";
     };
   };
 
@@ -171,21 +189,21 @@ in
           apiKey = "$BRAVE_API_KEY";
         };
         
-        # Email: Gmail with aliases
+        # Email: Configurable per bot
         email = {
           address = botCfg.emailAddress;
           smtp = {
-            host = "smtp.gmail.com";
+            host = botCfg.emailSmtpHost;
             port = 587;
-            user = "clawzero.agent@gmail.com";
-            password = "$GMAIL_APP_PASSWORD";
+            user = botCfg.emailSmtpUser;
+            password = "$${botCfg.emailPasswordSecret}";
           };
           
           # Guardrails: Only send to authorized recipients
           allowedRecipients = [
-            "sherif@abdalla.co.uk"  # Sherif
+            "sherif@abdalla.co.uk"
             "sherif+clawzero@abdalla.co.uk"
-            "pink@abdalla.co.uk"    # Yesim (pink bot owner)
+            "pink@abdalla.co.uk"
           ];
           
           # Require consent for new recipients

--- a/hosts/common/bot/bot-preset.nix
+++ b/hosts/common/bot/bot-preset.nix
@@ -2,6 +2,8 @@
 #
 # All bots inherit from this preset. No exceptions.
 #
+# FRAMEWORK: OpenClaw via nix-clawdbot (clawzero fork)
+#
 # STANDARD PATHS (same for all bots):
 #   - State: /var/lib/openclaw
 #   - Workspace: /var/lib/openclaw/workspace

--- a/hosts/common/bot/bot-preset.nix
+++ b/hosts/common/bot/bot-preset.nix
@@ -183,8 +183,9 @@ in
           
           # Guardrails: Only send to authorized recipients
           allowedRecipients = [
-            "sherif@abdalla.co.uk"  # Only Sherif can receive emails
+            "sherif@abdalla.co.uk"  # Sherif
             "sherif+clawzero@abdalla.co.uk"
+            "pink@abdalla.co.uk"    # Yesim (pink bot owner)
           ];
           
           # Require consent for new recipients

--- a/hosts/common/bot/bot-preset.nix
+++ b/hosts/common/bot/bot-preset.nix
@@ -10,9 +10,15 @@
 #   - Secrets: /run/secrets/openclaw-env
 #
 # DOPPLER CONFIGURATION:
-#   - DOPPLER_ENVIRONMENT (env)
-#   - DOPPLER_PROJECT (env)
-#   - DOPPLER_CONFIG (env)
+#   - DOPPLER_WORKSPACE = "claw"
+#   - DOPPLER_PROJECT = "{name}-claw"
+#   - DOPPLER_ENVIRONMENT = "dev_{name}"
+#   - DOPPLER_CONFIG = "dev_{name}"
+#
+# USER/HOST NAMING:
+#   - User: {name} (e.g., black, green, pink)
+#   - Host: {name}
+#   - SSH/GPG keys: {name}-claw
 #
 # FIRST-PARTY PLUGINS (enabled by default):
 #   - sag (TTS)
@@ -22,9 +28,11 @@
 #   {
 #     imports = [ ./bot-preset.nix ];
 #     bot = {
+#       enable = true;
 #       name = "black";
-#       owner = "zerodeth";
-#       project = "black";
+#       owner = "clawzero";
+#       project = "black-claw";
+#       environment = "dev_black";
 #       enablePlugins = [ "sag" ];
 #     };
 #   }
@@ -33,6 +41,7 @@
 
 let
   botCfg = config.bot;
+  userName = botCfg.name;  # User matches hostname
 in
 {
   options.bot = {
@@ -40,24 +49,23 @@ in
 
     name = lib.mkOption {
       type = lib.types.str;
-      description = "Bot hostname (e.g., black, green, pink)";
+      description = "Bot/machine hostname (e.g., black, green, pink)";
     };
 
     owner = lib.mkOption {
       type = lib.types.str;
-      description = "Bot owner username";
-      default = "zerodeth";
+      description = "GitHub owner (clawzero)";
+      default = "clawzero";
     };
 
     project = lib.mkOption {
       type = lib.types.str;
-      description = "Doppler project name";
+      description = "Doppler project name ({name}-claw)";
     };
 
     environment = lib.mkOption {
       type = lib.types.str;
-      description = "Doppler environment";
-      default = "dev";
+      description = "Doppler environment (dev_{name})";
     };
 
     enablePlugins = lib.mkOption {
@@ -68,16 +76,24 @@ in
   };
 
   config = lib.mkIf botCfg.enable {
+    # === HOSTNAME ===
+    networking.hostName = botCfg.name;
+
+    # === USER (matches hostname) ===
+    users.users.${userName} = {
+      isNormalUser = true;
+      description = botCfg.owner;
+      extraGroups = [ "networkmanager" "wheel" "tailscale" ];
+      openssh.authorizedKeys.keys = [
+        # SSH key pulled from GitHub during setup
+        # https://github.com/clawzero/dotfiles/raw/main/keys/${botCfg.name}-claw/id_ed25519.pub
+      ];
+    };
+
     # === BOOT ===
     boot.loader = {
       systemd-boot.enable = true;
       efi.canTouchEfiVariables = true;
-    };
-
-    # === NETWORKING ===
-    networking = {
-      firewall.enable = false;
-      hostName = botCfg.name;
     };
 
     i18n.defaultLocale = "en_GB.UTF-8";
@@ -126,8 +142,9 @@ in
         Restart = "always";
         RestartSec = "10s";
         Environment = [
-          "DOPPLER_ENVIRONMENT=${botCfg.environment}"
+          "DOPPLER_WORKSPACE=claw"
           "DOPPLER_PROJECT=${botCfg.project}"
+          "DOPPLER_ENVIRONMENT=${botCfg.environment}"
           "DOPPLER_CONFIG=${botCfg.environment}"
         ];
         EnvironmentFile = "/run/secrets/openclaw-env";
@@ -136,18 +153,11 @@ in
 
     # === DIRECTORIES ===
     systemd.tmpfiles.rules = [
-      "d /var/lib/openclaw 0755 root root -"
-      "d /var/lib/openclaw/workspace 0755 root root -"
-      "d /tmp/openclaw 0755 root root -"
+      "d /var/lib/openclaw 0755 ${userName} ${userName} -"
+      "d /var/lib/openclaw/workspace 0755 ${userName} ${userName} -"
+      "d /tmp/openclaw 0755 ${userName} ${userName} -"
       "d /run/secrets 0755 root root -"
     ];
-
-    # === USER ===
-    users.users.${botCfg.owner} = {
-      isNormalUser = true;
-      description = botCfg.owner;
-      extraGroups = [ "networkmanager" "wheel" "tailscale" ];
-    };
 
     # === PACKAGES ===
     environment.systemPackages = with pkgs; [

--- a/hosts/common/bot/bot-preset.nix
+++ b/hosts/common/bot/bot-preset.nix
@@ -1,0 +1,159 @@
+# bot-preset.nix - Standardized bot configuration
+#
+# All bots inherit from this preset. No exceptions.
+#
+# STANDARD PATHS (same for all bots):
+#   - State: /var/lib/openclaw
+#   - Workspace: /var/lib/openclaw/workspace
+#   - Config: /var/lib/openclaw/openclaw.json
+#   - Logs: /tmp/openclaw/openclaw-gateway.log
+#   - Secrets: /run/secrets/openclaw-env
+#
+# DOPPLER CONFIGURATION:
+#   - DOPPLER_ENVIRONMENT (env)
+#   - DOPPLER_PROJECT (env)
+#   - DOPPLER_CONFIG (env)
+#
+# FIRST-PARTY PLUGINS (enabled by default):
+#   - sag (TTS)
+#
+# USAGE:
+#   { config, pkgs, ... }:
+#   {
+#     imports = [ ./bot-preset.nix ];
+#     bot = {
+#       name = "black";
+#       owner = "zerodeth";
+#       project = "black";
+#       enablePlugins = [ "sag" ];
+#     };
+#   }
+
+{ config, lib, pkgs, ... }:
+
+let
+  botCfg = config.bot;
+in
+{
+  options.bot = {
+    enable = lib.mkEnableOption "Standardized bot configuration";
+
+    name = lib.mkOption {
+      type = lib.types.str;
+      description = "Bot hostname (e.g., black, green, pink)";
+    };
+
+    owner = lib.mkOption {
+      type = lib.types.str;
+      description = "Bot owner username";
+      default = "zerodeth";
+    };
+
+    project = lib.mkOption {
+      type = lib.types.str;
+      description = "Doppler project name";
+    };
+
+    environment = lib.mkOption {
+      type = lib.types.str;
+      description = "Doppler environment";
+      default = "dev";
+    };
+
+    enablePlugins = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      description = "First-party plugins to enable";
+      default = [ "sag" ];
+    };
+  };
+
+  config = lib.mkIf botCfg.enable {
+    # === BOOT ===
+    boot.loader = {
+      systemd-boot.enable = true;
+      efi.canTouchEfiVariables = true;
+    };
+
+    # === NETWORKING ===
+    networking = {
+      firewall.enable = false;
+      hostName = botCfg.name;
+    };
+
+    i18n.defaultLocale = "en_GB.UTF-8";
+    services.xserver.enable = false;
+
+    # === SSH (Tailscale) ===
+    services.openssh = {
+      enable = true;
+      settings.PasswordAuthentication = false;
+      settings.PermitRootLogin = "yes";
+    };
+
+    # === TAILSCALE ===
+    services.tailscale = {
+      enable = true;
+      usePredictableInterfaceNames = true;
+    };
+
+    # === OPENCLAW ===
+    programs.openclaw = {
+      enable = true;
+      systemd.enable = true;
+      stateDir = "/var/lib/openclaw";
+      workspaceDir = "/var/lib/openclaw/workspace";
+      
+      firstParty = {
+        sag.enable = lib.elem "sag" botCfg.enablePlugins;
+      };
+    };
+
+    # === DOPPLER ===
+    programs.doppler = {
+      enable = true;
+      json = true;
+    };
+
+    # === SYSTEMD SERVICE ===
+    systemd.services.openclaw-${botCfg.name} = {
+      description = "OpenClaw ${botCfg.name} - ${botCfg.owner}'s bot";
+      after = [ "network.target" "doppler.service" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "notify";
+        ExecStart = "${pkgs.openclaw}/bin/openclaw gateway";
+        WorkingDirectory = "/var/lib/openclaw";
+        Restart = "always";
+        RestartSec = "10s";
+        Environment = [
+          "DOPPLER_ENVIRONMENT=${botCfg.environment}"
+          "DOPPLER_PROJECT=${botCfg.project}"
+          "DOPPLER_CONFIG=${botCfg.environment}"
+        ];
+        EnvironmentFile = "/run/secrets/openclaw-env";
+      };
+    };
+
+    # === DIRECTORIES ===
+    systemd.tmpfiles.rules = [
+      "d /var/lib/openclaw 0755 root root -"
+      "d /var/lib/openclaw/workspace 0755 root root -"
+      "d /tmp/openclaw 0755 root root -"
+      "d /run/secrets 0755 root root -"
+    ];
+
+    # === USER ===
+    users.users.${botCfg.owner} = {
+      isNormalUser = true;
+      description = botCfg.owner;
+      extraGroups = [ "networkmanager" "wheel" "tailscale" ];
+    };
+
+    # === PACKAGES ===
+    environment.systemPackages = with pkgs; [
+      tailscale
+      git
+      doppler
+    ];
+  };
+}

--- a/hosts/nixos/nix-claw-black/README.md
+++ b/hosts/nixos/nix-claw-black/README.md
@@ -1,0 +1,25 @@
+# nix-claw-black
+
+Sherif's personal AI bot (OpenClaw).
+
+## Standards
+
+Following patterns from:
+- [nix-openclaw](https://github.com/openclaw/nix-openclaw) (official)
+- [ai-stack](https://github.com/clawzero/ai-stack) (fleet patterns)
+
+## Paths (standardized)
+
+| Path | Purpose |
+|------|---------|
+| `/var/lib/openclaw` | State directory |
+| `/var/lib/openclaw/workspace` | Workspace |
+| `/var/lib/openclaw/openclaw.json` | Config |
+| `/tmp/openclaw/openclaw-gateway.log` | Logs |
+
+## Integration
+
+- **OpenClaw**: Nix package via nix-openclaw (NOT Docker)
+- **Tailscale**: Mesh networking, hostname: `black`
+- **Doppler**: Secrets via environment variables
+- **Systemd**: Auto-start on boot

--- a/hosts/nixos/nix-claw-black/default.nix
+++ b/hosts/nixos/nix-claw-black/default.nix
@@ -1,0 +1,92 @@
+# nix-claw-black: Sherif's personal AI bot (OpenClaw)
+# Following nix-openclaw official patterns
+#
+# Standard paths (same across all bots):
+#   - State: ~/.openclaw
+#   - Workspace: ~/.openclaw/workspace
+#   - Config: ~/.openclaw/openclaw.json
+#   - Logs: /tmp/openclaw/openclaw-gateway.log
+#
+# Secrets: Doppler (environment variables at runtime)
+
+{ pkgs, unstablePkgs, inputs, ... }:
+
+{
+  imports = [
+    ./../common/nixos.nix
+    ./../common/packages.nix
+  ];
+
+  # Boot configuration
+  boot.loader = {
+    systemd-boot.enable = true;
+    efi.canTouchEfiVariables = true;
+  };
+
+  # Network configuration
+  networking = {
+    firewall.enable = false;
+    hostName = "black";
+    # Tailscale will handle networking
+  };
+
+  # Timezone
+  i18n.defaultLocale = "en_GB.UTF-8";
+
+  # Disable X server
+  services.xserver.enable = false;
+
+  # SSH (via Tailscale)
+  services.openssh = {
+    enable = true;
+    settings.PasswordAuthentication = false;
+    settings.PermitRootLogin = "yes";
+  };
+
+  # Tailscale mesh networking
+  services.tailscale = {
+    enable = true;
+    usePredictableInterfaceNames = true;
+  };
+
+  # OpenClaw via nix-openclaw (not Docker)
+  # Uses nix-openclaw home-manager module
+  programs.openclaw = {
+    enable = true;
+    systemd.enable = true;
+    
+    # Standard paths (same across all bots)
+    stateDir = "/var/lib/openclaw";
+    workspaceDir = "/var/lib/openclaw/workspace";
+    
+    # First-party plugins
+    firstParty = {
+      sag.enable = true;  # TTS
+    };
+    
+    # Bot configuration
+    config = {
+      # Channel will be configured per-environment via Doppler
+    };
+  };
+
+  # User configuration
+  users.users.zerodeth = {
+    isNormalUser = true;
+    description = "zerodeth";
+    extraGroups = [ "networkmanager" "wheel" "tailscale" ];
+  };
+
+  # Ensure directories exist
+  systemd.tmpfiles.rules = [
+    "d /var/lib/openclaw 0755 root root -"
+    "d /var/lib/openclaw/workspace 0755 root root -"
+    "d /tmp/openclaw 0755 root root -"
+  ];
+
+  # Packages
+  environment.systemPackages = with pkgs; [
+    tailscale
+    git
+  ];
+}

--- a/hosts/nixos/nix-claw-black/default.nix
+++ b/hosts/nixos/nix-claw-black/default.nix
@@ -2,12 +2,12 @@
 # Following nix-openclaw official patterns
 #
 # Standard paths (same across all bots):
-#   - State: ~/.openclaw
-#   - Workspace: ~/.openclaw/workspace
-#   - Config: ~/.openclaw/openclaw.json
+#   - State: /var/lib/openclaw
+#   - Workspace: /var/lib/openclaw/workspace
+#   - Config: /var/lib/openclaw/openclaw.json
 #   - Logs: /tmp/openclaw/openclaw-gateway.log
 #
-# Secrets: Doppler (environment variables at runtime)
+# Secrets: Doppler (runtime environment variables)
 
 { pkgs, unstablePkgs, inputs, ... }:
 
@@ -50,7 +50,6 @@
   };
 
   # OpenClaw via nix-openclaw (not Docker)
-  # Uses nix-openclaw home-manager module
   programs.openclaw = {
     enable = true;
     systemd.enable = true;
@@ -64,11 +63,48 @@
       sag.enable = true;  # TTS
     };
     
-    # Bot configuration
+    # Bot configuration (per-environment via Doppler)
     config = {
-      # Channel will be configured per-environment via Doppler
+      # Config loaded from Doppler at runtime
     };
   };
+
+  # Doppler integration
+  # Doppler provides secrets via environment variables
+  programs.doppler = {
+    enable = true;
+    json = true;
+  };
+
+  # Systemd service for OpenClaw with Doppler environment
+  # Doppler secrets injected at runtime
+  systemd.services.openclaw-black = {
+    description = "OpenClaw Black - Sherif's personal AI";
+    after = [ "network.target" "doppler.service" ];
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "notify";
+      ExecStart = "${pkgs.openclaw}/bin/openclaw gateway";
+      WorkingDirectory = "/var/lib/openclaw";
+      Restart = "always";
+      RestartSec = "10s";
+      # Doppler environment variables
+      Environment = [
+        "DOPPLER_ENVIRONMENT=dev"
+        "DOPPLER_PROJECT=black"
+        "DOPPLER_CONFIG=dev"
+      ];
+      # EnvironmentFile from Doppler secrets
+      EnvironmentFile = "/run/secrets/openclaw-env";
+    };
+  };
+
+  # Generate Doppler secrets file
+  # This is a template - actual values come from Doppler at runtime
+  systemd.tmpfiles.rules = [
+    "d /run/secrets 0755 root root -"
+    "f /run/secrets/openclaw-env 0600 root root -"
+  ];
 
   # User configuration
   users.users.zerodeth = {
@@ -82,11 +118,13 @@
     "d /var/lib/openclaw 0755 root root -"
     "d /var/lib/openclaw/workspace 0755 root root -"
     "d /tmp/openclaw 0755 root root -"
+    "d /run/secrets 0755 root root -"
   ];
 
   # Packages
   environment.systemPackages = with pkgs; [
     tailscale
     git
+    doppler
   ];
 }

--- a/hosts/nixos/nix-claw-black/default.nix
+++ b/hosts/nixos/nix-claw-black/default.nix
@@ -18,5 +18,11 @@
     environment = "dev_black";
     enablePlugins = [ "sag" ];
     imageBackend = "openai";  # openai, gemini, or brave
+    
+    # Email: Gmail alias for black
+    emailAddress = "clawzero.agent+black@gmail.com";
+    emailSmtpHost = "smtp.gmail.com";
+    emailSmtpUser = "clawzero.agent@gmail.com";
+    emailPasswordSecret = "GMAIL_APP_PASSWORD";
   };
 }

--- a/hosts/nixos/nix-claw-black/default.nix
+++ b/hosts/nixos/nix-claw-black/default.nix
@@ -1,130 +1,21 @@
-# nix-claw-black: Sherif's personal AI bot (OpenClaw)
-# Following nix-openclaw official patterns
-#
-# Standard paths (same across all bots):
-#   - State: /var/lib/openclaw
-#   - Workspace: /var/lib/openclaw/workspace
-#   - Config: /var/lib/openclaw/openclaw.json
-#   - Logs: /tmp/openclaw/openclaw-gateway.log
-#
-# Secrets: Doppler (runtime environment variables)
+# nix-claw-black: Sherif's personal AI bot
+# Uses standardized bot preset
 
-{ pkgs, unstablePkgs, inputs, ... }:
+{ pkgs, ... }:
 
 {
   imports = [
     ./../common/nixos.nix
     ./../common/packages.nix
+    ./../common/bot/bot-preset.nix
   ];
 
-  # Boot configuration
-  boot.loader = {
-    systemd-boot.enable = true;
-    efi.canTouchEfiVariables = true;
-  };
-
-  # Network configuration
-  networking = {
-    firewall.enable = false;
-    hostName = "black";
-    # Tailscale will handle networking
-  };
-
-  # Timezone
-  i18n.defaultLocale = "en_GB.UTF-8";
-
-  # Disable X server
-  services.xserver.enable = false;
-
-  # SSH (via Tailscale)
-  services.openssh = {
+  bot = {
     enable = true;
-    settings.PasswordAuthentication = false;
-    settings.PermitRootLogin = "yes";
+    name = "black";
+    owner = "zerodeth";
+    project = "black";
+    environment = "dev";
+    enablePlugins = [ "sag" ];
   };
-
-  # Tailscale mesh networking
-  services.tailscale = {
-    enable = true;
-    usePredictableInterfaceNames = true;
-  };
-
-  # OpenClaw via nix-openclaw (not Docker)
-  programs.openclaw = {
-    enable = true;
-    systemd.enable = true;
-    
-    # Standard paths (same across all bots)
-    stateDir = "/var/lib/openclaw";
-    workspaceDir = "/var/lib/openclaw/workspace";
-    
-    # First-party plugins
-    firstParty = {
-      sag.enable = true;  # TTS
-    };
-    
-    # Bot configuration (per-environment via Doppler)
-    config = {
-      # Config loaded from Doppler at runtime
-    };
-  };
-
-  # Doppler integration
-  # Doppler provides secrets via environment variables
-  programs.doppler = {
-    enable = true;
-    json = true;
-  };
-
-  # Systemd service for OpenClaw with Doppler environment
-  # Doppler secrets injected at runtime
-  systemd.services.openclaw-black = {
-    description = "OpenClaw Black - Sherif's personal AI";
-    after = [ "network.target" "doppler.service" ];
-    wantedBy = [ "multi-user.target" ];
-    serviceConfig = {
-      Type = "notify";
-      ExecStart = "${pkgs.openclaw}/bin/openclaw gateway";
-      WorkingDirectory = "/var/lib/openclaw";
-      Restart = "always";
-      RestartSec = "10s";
-      # Doppler environment variables
-      Environment = [
-        "DOPPLER_ENVIRONMENT=dev"
-        "DOPPLER_PROJECT=black"
-        "DOPPLER_CONFIG=dev"
-      ];
-      # EnvironmentFile from Doppler secrets
-      EnvironmentFile = "/run/secrets/openclaw-env";
-    };
-  };
-
-  # Generate Doppler secrets file
-  # This is a template - actual values come from Doppler at runtime
-  systemd.tmpfiles.rules = [
-    "d /run/secrets 0755 root root -"
-    "f /run/secrets/openclaw-env 0600 root root -"
-  ];
-
-  # User configuration
-  users.users.zerodeth = {
-    isNormalUser = true;
-    description = "zerodeth";
-    extraGroups = [ "networkmanager" "wheel" "tailscale" ];
-  };
-
-  # Ensure directories exist
-  systemd.tmpfiles.rules = [
-    "d /var/lib/openclaw 0755 root root -"
-    "d /var/lib/openclaw/workspace 0755 root root -"
-    "d /tmp/openclaw 0755 root root -"
-    "d /run/secrets 0755 root root -"
-  ];
-
-  # Packages
-  environment.systemPackages = with pkgs; [
-    tailscale
-    git
-    doppler
-  ];
 }

--- a/hosts/nixos/nix-claw-black/default.nix
+++ b/hosts/nixos/nix-claw-black/default.nix
@@ -13,9 +13,9 @@
   bot = {
     enable = true;
     name = "black";
-    owner = "zerodeth";
-    project = "black";
-    environment = "dev";
+    owner = "clawzero";
+    project = "black-claw";
+    environment = "dev_black";
     enablePlugins = [ "sag" ];
   };
 }

--- a/hosts/nixos/nix-claw-black/default.nix
+++ b/hosts/nixos/nix-claw-black/default.nix
@@ -17,5 +17,6 @@
     project = "black-claw";
     environment = "dev_black";
     enablePlugins = [ "sag" ];
+    imageBackend = "openai";  # openai, gemini, or brave
   };
 }

--- a/hosts/nixos/nix-claw-black/install-nix.sh
+++ b/hosts/nixos/nix-claw-black/install-nix.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Install NixOS for nix-claw-black
+# Usage: sh install-nix.sh nix-claw-black
+
+set -euo pipefail
+
+# Check if running as root
+if [ "$EUID" -ne 0 ]; then
+  echo "This script must be run as root"
+  exit 1
+fi
+
+# Clone kosnip if not already present
+if [ ! -d "/root/kosnip" ]; then
+  git clone https://github.com/ZeroDeth/kosnip.git /root/kosnip
+fi
+
+cd /root/kosnip/hosts/nixos/nix-claw-black
+
+# Run disko to partition and format disk
+nix --experimental-features "nix-command flakes" run github:nix-community/disko -- --mode disko ./disko.nix
+
+# Generate nixos configuration
+nixos-generate-config --no-filesystems --root /mnt
+
+# Copy hardware configuration
+cp ./hardware-configuration.nix /mnt/etc/nixos/
+
+# Install NixOS
+export NIXPKGS_ALLOW_UNFREE=1
+nixos-install --root /mnt --flake .#nix-claw-black --impure
+
+echo "Installation complete!"
+echo "Before rebooting, set root password:"
+echo "  nixos-enter --root /mnt"
+echo "  passwd"
+echo "  exit"
+echo "  reboot"


### PR DESCRIPTION
## Summary

Add nix-claw-black machine following **nix-openclaw official patterns**.

## Changes

-  - NixOS configuration with OpenClaw
-  - Installation script

## Standards (same across all bots)

| Path | Purpose |
|------|---------|
|  | State directory |
|  | Workspace |
|  | Config |
|  | Logs |

## Integration

- **OpenClaw**: Nix package via nix-openclaw (NOT Docker)
- **Tailscale**: Mesh networking, hostname: 
- **Doppler**: Secrets via environment variables at runtime
- **Systemd**: Auto-start on boot

## Pattern Source

Following patterns from:
-  (official): https://github.com/openclaw/nix-openclaw
- : Bot fleet patterns

## Notes

- No Docker - OpenClaw runs as Nix package
- Standardized paths for all bots
- Sensitive info in Doppler, not in code

Review: https://github.com/ZeroDeth/kosnip/pull/new/pr/nix-claw-black

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added nix-claw-black system with OpenClaw service, Tailscale mesh networking, Doppler secrets integration, and default packages
  * Added an automated installer to partition, generate and install the system with post‑install guidance

* **Chores**
  * Configured bootloader/EFI, networking, locale, disabled X server, tmpfiles and a non‑root bot user

* **Documentation**
  * Added project README, common bot preset README and PREREQUISITES guide

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->